### PR TITLE
Use caml_enter_blocking_section() for some stubs

### DIFF
--- a/lib/time.c
+++ b/lib/time.c
@@ -25,4 +25,14 @@ CAMLprim value ml_al_init_timeout(value seconds)
 }
 
 
-ml_function_1arg(al_rest, Double_val)
+CAMLprim value ml_al_rest(value seconds)
+{
+    CAMLparam1(seconds);
+    double c_secs = Double_val(seconds);
+
+    caml_enter_blocking_section();
+    al_rest(c_secs);
+    caml_leave_blocking_section();
+
+    CAMLreturn(Val_unit);
+}

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,16 @@
+(test
+ (name test_al_rest)
+ (enabled_if %{env:RUN_GUI_TEST=false})
+ (libraries threads allegro5 allegro5_main))
+(test
+ (name test_al_wait_for_event)
+ (enabled_if %{env:RUN_GUI_TEST=false})
+ (libraries threads allegro5 allegro5_main))
+(test
+ (name test_al_wait_for_event_timed)
+ (enabled_if %{env:RUN_GUI_TEST=false})
+ (libraries threads allegro5 allegro5_main))
+(test
+ (name test_al_wait_for_event_until)
+ (enabled_if %{env:RUN_GUI_TEST=false})
+ (libraries threads allegro5 allegro5_main))

--- a/test/test_al_rest.ml
+++ b/test/test_al_rest.ml
@@ -1,0 +1,28 @@
+let () =
+  (* Test that al_rest doesn't block the current domain. *)
+  Al5.init ();
+  let value = ref 0 in
+  let t =
+    Thread.create
+      (fun () ->
+        Thread.delay 1.0;
+        value := 99)
+      ()
+  in
+
+  let before_rest = !value in
+  Al5.rest 3.0;
+  let after_rest = !value in
+  Thread.join t;
+
+  let result =
+    if before_rest = 0 && after_rest = 99 then Result.ok ()
+    else Result.error "al_rest blocked thread execution"
+  in
+  Format.printf "test_al_rest: %a"
+    (Format.pp_print_result
+       ~ok:(fun out _v -> Format.fprintf out "ok")
+       ~error:Format.pp_print_string)
+    result;
+
+  exit (match result with Result.Ok _ -> 0 | _ -> 1)

--- a/test/test_al_wait_for_event.ml
+++ b/test/test_al_wait_for_event.ml
@@ -1,0 +1,31 @@
+let () =
+  (* Test that al_wait_for_event doesn't block the current domain. *)
+  Al5.init ();
+  let event_queue = Al5.create_event_queue () in
+  let wakeup_timer = Al5.create_timer 3.0 in
+  Al5.register_event_source event_queue (Al5.get_timer_event_source wakeup_timer) ;
+  let value = ref 0 in
+  let t =
+    Thread.create
+      (fun () ->
+        Thread.delay 1.0;
+        value := 99)
+      ()
+  in
+  Al5.start_timer wakeup_timer;
+  let before_wait = !value in
+  let _ = Al5.wait_for_event event_queue in
+  let after_wait = !value in
+  Thread.join t;
+
+  let result =
+    if before_wait = 0 && after_wait = 99 then Result.ok ()
+    else Result.error "al_wait_for_event blocked thread execution"
+  in
+  Format.printf "test_al_wait_for_event: %a"
+    (Format.pp_print_result
+       ~ok:(fun out _v -> Format.fprintf out "ok")
+       ~error:Format.pp_print_string)
+    result;
+
+  exit (match result with Result.Ok _ -> 0 | _ -> 1)

--- a/test/test_al_wait_for_event_timed.ml
+++ b/test/test_al_wait_for_event_timed.ml
@@ -1,0 +1,28 @@
+let () =
+  (* Test that al_wait_for_event_timed doesn't block the current domain. *)
+  Al5.init ();
+  let event_queue = Al5.create_event_queue () in
+  let value = ref 0 in
+  let t =
+    Thread.create
+      (fun () ->
+        Thread.delay 1.0;
+        value := 99)
+      ()
+  in
+  let before_wait = !value in
+  let _ = Al5.wait_for_event_timed event_queue false 3.0 in
+  let after_wait = !value in
+  Thread.join t;
+
+  let result =
+    if before_wait = 0 && after_wait = 99 then Result.ok ()
+    else Result.error "al_wait_for_event_timed blocked thread execution"
+  in
+  Format.printf "test_al_wait_for_event_timed: %a"
+    (Format.pp_print_result
+       ~ok:(fun out _v -> Format.fprintf out "ok")
+       ~error:Format.pp_print_string)
+    result;
+
+  exit (match result with Result.Ok _ -> 0 | _ -> 1)

--- a/test/test_al_wait_for_event_until.ml
+++ b/test/test_al_wait_for_event_until.ml
@@ -1,0 +1,29 @@
+let () =
+  (* Test that al_wait_for_event_until doesn't block the current domain. *)
+  Al5.init ();
+  let event_queue = Al5.create_event_queue () in
+  let timeout = Al5.init_timeout 3.0 in
+  let value = ref 0 in
+  let t =
+    Thread.create
+      (fun () ->
+        Thread.delay 1.0;
+        value := 99)
+      ()
+  in
+  let before_wait = !value in
+  let _ = Al5.wait_for_event_until event_queue false timeout in
+  let after_wait = !value in
+  Thread.join t;
+
+  let result =
+    if before_wait = 0 && after_wait = 99 then Result.ok ()
+    else Result.error "al_wait_for_event_until blocked thread execution"
+  in
+  Format.printf "test_al_wait_for_event_until: %a"
+    (Format.pp_print_result
+       ~ok:(fun out _v -> Format.fprintf out "ok")
+       ~error:Format.pp_print_string)
+    result;
+
+  exit (match result with Result.Ok _ -> 0 | _ -> 1)


### PR DESCRIPTION
This patch adds calls to caml_enter_blocking_section() and caml_leave_blocking_section() to the following C stub functions so that they do not block the domain that they are running in:

* ml_al_wait_for_event
* ml_al_wait_for_event_timed
* ml_al_wait_for_event_until
* ml_al_rest

This also adds some small test cases for this functionality. The tests are disabled by default but can be enabled by setting the RUN_GUI_TEST environment variable to true.

The test scenario for all of these is similar: launch a thread that delays 1 second and then updates a ref variable. Call one of the modified functions and have it block the thread for 3 seconds. Verify that the first thread executed during that time by checking the ref variable.

* test_al_rest.ml
* test_al_wait_for_event_until.ml
* test_al_wait_for_event_timed.ml
* test_al_wait_for_event.ml