### PR TITLE
Improve type soundness of flags

### DIFF
--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -21,27 +21,6 @@ type mixer
 type sample
 type sample_id
 
-module type FLAG = sig
-  type flags = private int
-
-  val none : flags
-  val lnot : flags -> int
-  val ( lor ) : flags -> flags -> flags
-  val ( land ) : flags -> int -> flags
-  val ( lxor ) : flags -> flags -> flags
-end
-
-(**/**)
-module Flag = struct
-  type flags = int
-
-  let none  = 0
-  let lnot = lnot
-  let ( lor ) = ( lor )
-  let ( land ) = ( land )
-  let ( lxor ) = ( lxor )
-end
-
 (** {2 Aggregation types} *)
 
 type pos = float * float
@@ -95,6 +74,27 @@ module TouchState = struct
 end
 
 (** {2 Enumerations and flags} *)
+
+module type FLAG = sig
+  type flags = private int
+
+  val none : flags
+  val lnot : flags -> int
+  val ( lor ) : flags -> flags -> flags
+  val ( land ) : flags -> int -> flags
+  val ( lxor ) : flags -> flags -> flags
+end
+
+module Flag = struct
+  type flags = int
+
+  let none = 0
+
+  let lnot = lnot
+  let ( lor ) = ( lor )
+  let ( land ) = ( land )
+  let ( lxor ) = ( lxor )
+end
 
 module Display = struct
   include Flag
@@ -585,7 +585,7 @@ external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> 
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
 external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> float -> Flip.flags -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
 external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"

--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -299,11 +299,11 @@ module DisplayOrientation = struct
   | FACE_DOWN
 end
 
-module Draw = struct
+module Flip = struct
   include Flag
 
-  let flip_horizontal = 1 lsl 0
-  let flip_vertical = 1 lsl 1
+  let horizontal = 1 lsl 0
+  let vertical = 1 lsl 1
 end
 
 module ShaderType = struct
@@ -578,16 +578,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> pos -> Draw.flags -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Draw.flags -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> pos -> Flip.flags -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Draw.flags -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"

--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -21,6 +21,25 @@ type mixer
 type sample
 type sample_id
 
+module type FLAG = sig
+  type flags = private int
+
+  val lnot : flags -> int
+  val ( lor ) : flags -> flags -> flags
+  val ( land ) : flags -> int -> flags
+  val ( lxor ) : flags -> int -> int
+end
+
+(**/**)
+module Flag = struct
+  type flags = int
+
+  let lnot = lnot
+  let ( lor ) = ( lor )
+  let ( land ) = ( land )
+  let ( lxor ) = ( lxor )
+end
+
 (** {2 Aggregation types} *)
 
 type pos = float * float
@@ -76,28 +95,33 @@ end
 (** {2 Enumerations and flags} *)
 
 module Display = struct
-  let windowed = 1 lsl 0
-  let fullscreen_window = 1 lsl 1
-  let fullscreen = 1 lsl 2
-  let resizable = 1 lsl 3
-  let maximized = 1 lsl 4
-  let opengl = 1 lsl 5
-  let opengl_3_0 = 1 lsl 6
-  let opengl_forward_compatible = 1 lsl 7
-  let opengl_es_profile = 1 lsl 8
-  let opengl_core_profile = 1 lsl 9
-  let direct3d = 1 lsl 10
-  let programmable_pipeline = 1 lsl 11
-  let frameless = 1 lsl 12
-  let generate_expose_events = 1 lsl 13
-  let gtk_toplevel = 1 lsl 14
-  let drag_and_drop = 1 lsl 15
+  include Flag
+
+  let windowed                    = 1 lsl 0
+  let fullscreen                  = 1 lsl 1
+  let opengl                      = 1 lsl 2
+  let direct3d_internal           = 1 lsl 3
+  let resizable                   = 1 lsl 4
+  let frameless                   = 1 lsl 5
+  let generate_expose_events      = 1 lsl 6
+  let opengl_3_0                  = 1 lsl 7
+  let opengl_forward_compatible   = 1 lsl 8
+  let fullscreen_window           = 1 lsl 9
+  let minimized                   = 1 lsl 10
+  let programmable_pipeline       = 1 lsl 11
+  let gtk_toplevel                = 1 lsl 12
+  let maximized                   = 1 lsl 13
+  let opengl_es_profile           = 1 lsl 14
+  let opengl_core_profile         = 1 lsl 15
+  let drag_and_drop               = 1 lsl 16
 end
 
 module Bitmap = struct
-  let no_premultiplied_alpha = 1 lsl 0
-  let keep_index = 1 lsl 1
-  let keep_bitmap_format = 1 lsl 2
+  include Flag
+
+  let keep_bitmap_format = 1 lsl 1
+  let no_premultiplied_alpha = 1 lsl 9
+  let keep_index = 1 lsl 11
 end
 
 module Key = struct
@@ -236,6 +260,8 @@ module Key = struct
 end
 
 module Keymod = struct
+  include Flag
+
   let shift = 1 lsl 0
   let ctrl = 1 lsl 1
   let alt = 1 lsl 2
@@ -255,6 +281,8 @@ module Keymod = struct
 end
 
 module MouseButton = struct
+  type t = int
+
   let left = 1
   let right = 2
   let middle = 3
@@ -271,9 +299,11 @@ module DisplayOrientation = struct
   | FACE_DOWN
 end
 
-module Flip = struct
-  let horizontal = 1 lsl 0
-  let vertical = 1 lsl 1
+module Draw = struct
+  include Flag
+
+  let flip_horizontal = 1 lsl 0
+  let flip_vertical = 1 lsl 1
 end
 
 module ShaderType = struct
@@ -322,16 +352,29 @@ module LineCap = struct
 end
 
 module Text = struct
-  let align_left = 1 lsl 0
-  let align_centre = 1 lsl 1
-  let align_right = 1 lsl 2
-  let align_integer = 1 lsl 3
+  type flags = int
+  type align_integer_flag = int
+
+  let ( lor ) = (lor)
+
+  let align_left = 0
+  let align_centre = 1 lsl 0
+  let align_right = 1 lsl 1
+  let align_integer = 1 lsl 2
 end
 
 module Ttf = struct
+  include Flag
+
   let no_kerning = 1 lsl 0
   let monochrome = 1 lsl 1
   let no_autohint = 1 lsl 2
+end
+
+module BitmapFont = struct
+  include Flag
+
+  let no_premultiplied_alpha = Bitmap.no_premultiplied_alpha
 end
 
 module Playmode = struct
@@ -340,6 +383,15 @@ module Playmode = struct
   | LOOP
   | LOOP_ONCE
   | BIDIR
+end
+
+module KeyboardLeds = struct
+  include Flag
+
+  let numlock = Keymod.numlock
+  let capslock = Keymod.capslock
+  let scrolllock = Keymod.scrolllock
+  let default = -1
 end
 
 (** {2 Events} *)
@@ -363,7 +415,7 @@ module Event = struct
       y : int;
       z : int;
       w : int;
-      button : int;
+      button : MouseButton.t;
       pressure : float;
       display : display;
     }
@@ -526,16 +578,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> pos -> int -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> int -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags ->pos -> pos -> pos -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> int -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> float -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> int -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> float -> int -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> float -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> int -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> float -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"
@@ -555,7 +607,7 @@ external is_bitmap_drawing_held : unit -> bool = "ml_al_is_bitmap_drawing_held"
 
 (** {2 Image I/O} *)
 
-external register_bitmap_loader : string -> (string -> int -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
+external register_bitmap_loader : string -> (string -> Bitmap.flags -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
 external register_bitmap_saver : string -> (string -> bitmap -> bool) option -> unit = "ml_al_register_bitmap_saver"
 external load_bitmap : string -> bitmap = "ml_al_load_bitmap"
 external load_bitmap_flags : string -> int -> bitmap = "ml_al_load_bitmap_flags"
@@ -603,7 +655,7 @@ external get_keyboard_state : unit -> KeyboardState.t = "ml_al_get_keyboard_stat
 external key_down : KeyboardState.t -> Key.t -> bool = "ml_al_key_down"
 external keycode_to_name : Key.t -> string = "ml_al_keycode_to_name"
 external can_set_keyboard_leds : unit -> bool = "ml_al_can_set_keyboard_leds"
-external set_keyboard_leds : int -> unit = "ml_al_set_keyboard_leds"
+external set_keyboard_leds : KeyboardLeds.flags -> unit = "ml_al_set_keyboard_leds"
 
 
 (** {1 Mouse routines} *)
@@ -619,7 +671,7 @@ external get_mouse_num_axis : unit -> int = "ml_al_get_mouse_num_axes"
 external get_mouse_num_buttons : unit -> int = "ml_al_get_mouse_num_buttons"
 external get_mouse_state : unit -> MouseState.t = "ml_al_get_mouse_state"
 external get_mouse_state_axis : MouseState.t -> int -> int = "ml_al_get_mouse_state_axis"
-external mouse_button_down : MouseState.t -> int -> bool = "ml_al_mouse_button_down"
+external mouse_button_down : MouseState.t -> MouseButton.t -> bool = "ml_al_mouse_button_down"
 external set_mouse_xy : display -> int -> int -> bool = "ml_al_set_mouse_xy"
 external set_mouse_z : int -> bool = "ml_al_set_mouse_z"
 external set_mouse_w : int -> bool = "ml_al_set_mouse_w"
@@ -765,8 +817,8 @@ external get_font_line_height : font -> int = "ml_al_get_font_line_height"
 external get_font_ascent : font -> int = "ml_al_get_font_ascent"
 external get_font_descent : font -> int = "ml_al_get_font_descent"
 external get_text_width : font -> string -> int = "ml_al_get_text_width"
-external draw_text : font -> color -> pos -> int -> string -> unit = "ml_al_draw_text"
-external draw_justified_text : font -> color -> pos -> float -> float -> int -> string -> unit =
+external draw_text : font -> ?flags: Text.flags -> color -> pos -> string -> unit = "ml_al_draw_text"
+external draw_justified_text : font -> ?flags: Text.flags -> color -> pos -> float -> float -> string -> unit =
   "ml_al_draw_justified_text_bytecode" "ml_al_draw_justified_text"
 external get_text_dimensions : font -> string -> int * int * int * int = "ml_al_get_text_dimensions"
 external get_font_ranges : font -> (int * int) array = "ml_al_get_font_ranges"
@@ -777,7 +829,7 @@ external get_fallback_font : font -> font = "ml_al_get_fallback_font"
 
 external grab_font_from_bitmap : bitmap -> (int * int) array -> font = "ml_al_grab_font_from_bitmap"
 external load_bitmap_font : string -> font = "ml_al_load_bitmap_font"
-external load_bitmap_font_flags : string -> int -> font = "ml_al_load_bitmap_font_flags"
+external load_bitmap_font_flags : string -> BitmapFont.flags -> font = "ml_al_load_bitmap_font_flags"
 external create_builtin_font : unit -> font = "ml_al_create_builtin_font"
 
 (** {2 TTF fonts} *)
@@ -786,8 +838,8 @@ external init_ttf_addon : unit -> unit = "ml_al_init_ttf_addon"
 external is_ttf_addon_initialized : unit -> bool = "ml_al_is_ttf_addon_initialized"
 external shutdown_ttf_addon : unit -> unit = "ml_al_shutdown_ttf_addon"
 external get_allegro_ttf_version : unit -> int = "ml_al_get_allegro_ttf_version"
-external load_ttf_font : string -> int -> int -> font = "ml_al_load_ttf_font"
-external load_ttf_font_stretch : string -> int -> int -> int -> font = "ml_al_load_ttf_font_stretch"
+external load_ttf_font : string -> ?flags: Ttf.flags -> int -> font = "ml_al_load_ttf_font"
+external load_ttf_font_stretch : string -> ?flags: Ttf.flags -> int -> int -> font = "ml_al_load_ttf_font_stretch"
 
 
 (** {1 Primitives addon} *)

--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -579,7 +579,7 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
 external draw_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags ->pos -> pos -> pos -> unit =
+external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
 external draw_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> float -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"

--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -283,8 +283,6 @@ module Keymod = struct
 end
 
 module MouseButton = struct
-  type t = int
-
   let left = 1
   let right = 2
   let middle = 3
@@ -417,7 +415,7 @@ module Event = struct
       y : int;
       z : int;
       w : int;
-      button : MouseButton.t;
+      button : int;
       pressure : float;
       display : display;
     }
@@ -673,7 +671,7 @@ external get_mouse_num_axis : unit -> int = "ml_al_get_mouse_num_axes"
 external get_mouse_num_buttons : unit -> int = "ml_al_get_mouse_num_buttons"
 external get_mouse_state : unit -> MouseState.t = "ml_al_get_mouse_state"
 external get_mouse_state_axis : MouseState.t -> int -> int = "ml_al_get_mouse_state_axis"
-external mouse_button_down : MouseState.t -> MouseButton.t -> bool = "ml_al_mouse_button_down"
+external mouse_button_down : MouseState.t -> int -> bool = "ml_al_mouse_button_down"
 external set_mouse_xy : display -> int -> int -> bool = "ml_al_set_mouse_xy"
 external set_mouse_z : int -> bool = "ml_al_set_mouse_z"
 external set_mouse_w : int -> bool = "ml_al_set_mouse_w"

--- a/lib/al5.ml
+++ b/lib/al5.ml
@@ -24,16 +24,18 @@ type sample_id
 module type FLAG = sig
   type flags = private int
 
+  val none : flags
   val lnot : flags -> int
   val ( lor ) : flags -> flags -> flags
   val ( land ) : flags -> int -> flags
-  val ( lxor ) : flags -> int -> int
+  val ( lxor ) : flags -> flags -> flags
 end
 
 (**/**)
 module Flag = struct
   type flags = int
 
+  let none  = 0
   let lnot = lnot
   let ( lor ) = ( lor )
   let ( land ) = ( land )
@@ -578,16 +580,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> pos -> Draw.flags -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Draw.flags -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> float -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Draw.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> float -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> float -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"
@@ -610,7 +612,7 @@ external is_bitmap_drawing_held : unit -> bool = "ml_al_is_bitmap_drawing_held"
 external register_bitmap_loader : string -> (string -> Bitmap.flags -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
 external register_bitmap_saver : string -> (string -> bitmap -> bool) option -> unit = "ml_al_register_bitmap_saver"
 external load_bitmap : string -> bitmap = "ml_al_load_bitmap"
-external load_bitmap_flags : string -> int -> bitmap = "ml_al_load_bitmap_flags"
+external load_bitmap_flags : string -> Bitmap.flags -> bitmap = "ml_al_load_bitmap_flags"
 external save_bitmap : string -> bitmap -> unit = "ml_al_save_bitmap"
 external identify_bitmap : string -> string = "ml_al_identify_bitmap"
 
@@ -817,8 +819,8 @@ external get_font_line_height : font -> int = "ml_al_get_font_line_height"
 external get_font_ascent : font -> int = "ml_al_get_font_ascent"
 external get_font_descent : font -> int = "ml_al_get_font_descent"
 external get_text_width : font -> string -> int = "ml_al_get_text_width"
-external draw_text : font -> ?flags: Text.flags -> color -> pos -> string -> unit = "ml_al_draw_text"
-external draw_justified_text : font -> ?flags: Text.flags -> color -> pos -> float -> float -> string -> unit =
+external draw_text : font -> color -> pos -> Text.flags -> string -> unit = "ml_al_draw_text"
+external draw_justified_text : font -> color -> pos -> float -> float -> Text.flags -> string -> unit =
   "ml_al_draw_justified_text_bytecode" "ml_al_draw_justified_text"
 external get_text_dimensions : font -> string -> int * int * int * int = "ml_al_get_text_dimensions"
 external get_font_ranges : font -> (int * int) array = "ml_al_get_font_ranges"
@@ -838,8 +840,8 @@ external init_ttf_addon : unit -> unit = "ml_al_init_ttf_addon"
 external is_ttf_addon_initialized : unit -> bool = "ml_al_is_ttf_addon_initialized"
 external shutdown_ttf_addon : unit -> unit = "ml_al_shutdown_ttf_addon"
 external get_allegro_ttf_version : unit -> int = "ml_al_get_allegro_ttf_version"
-external load_ttf_font : string -> ?flags: Ttf.flags -> int -> font = "ml_al_load_ttf_font"
-external load_ttf_font_stretch : string -> ?flags: Ttf.flags -> int -> int -> font = "ml_al_load_ttf_font_stretch"
+external load_ttf_font : string -> int -> Ttf.flags -> font = "ml_al_load_ttf_font"
+external load_ttf_font_stretch : string -> int -> int -> Ttf.flags -> font = "ml_al_load_ttf_font_stretch"
 
 
 (** {1 Primitives addon} *)

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -28,12 +28,13 @@ type pos = float * float
 module type FLAG = sig
   type flags = private int
 
+  val none : flags
   val lnot : flags -> int
   val ( lor ) : flags -> flags -> flags
   val ( land ) : flags -> int -> flags
   (** You may use type coercion i.e. [(my_flags :> int)]. *)
 
-  val ( lxor ) : flags -> int -> int
+  val ( lxor ) : flags -> flags -> flags
 end
 
 module DisplayMode : sig
@@ -570,16 +571,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags ->pos -> pos -> pos -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> pos -> Draw.flags -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Draw.flags -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> float -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Draw.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos ->pos -> pos -> pos -> float -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos ->pos -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> float -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Draw.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"
@@ -602,7 +603,7 @@ external is_bitmap_drawing_held : unit -> bool = "ml_al_is_bitmap_drawing_held"
 external register_bitmap_loader : string -> (string -> Bitmap.flags -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
 external register_bitmap_saver : string -> (string -> bitmap -> bool) option -> unit = "ml_al_register_bitmap_saver"
 external load_bitmap : string -> bitmap = "ml_al_load_bitmap"
-external load_bitmap_flags : string -> int -> bitmap = "ml_al_load_bitmap_flags"
+external load_bitmap_flags : string -> Bitmap.flags -> bitmap = "ml_al_load_bitmap_flags"
 external save_bitmap : string -> bitmap -> unit = "ml_al_save_bitmap"
 external identify_bitmap : string -> string = "ml_al_identify_bitmap"
 
@@ -808,8 +809,8 @@ external get_font_line_height : font -> int = "ml_al_get_font_line_height"
 external get_font_ascent : font -> int = "ml_al_get_font_ascent"
 external get_font_descent : font -> int = "ml_al_get_font_descent"
 external get_text_width : font -> string -> int = "ml_al_get_text_width"
-external draw_text : font -> ?flags: Text.flags -> color -> pos -> string -> unit = "ml_al_draw_text"
-external draw_justified_text : font -> ?flags: Text.align_integer_flag -> color -> pos -> float -> float -> string -> unit =
+external draw_text : font -> color -> pos -> Text.flags -> string -> unit = "ml_al_draw_text"
+external draw_justified_text : font -> color -> pos -> float -> float -> Text.align_integer_flag -> string -> unit =
   "ml_al_draw_justified_text_bytecode" "ml_al_draw_justified_text"
 external get_text_dimensions : font -> string -> int * int * int * int = "ml_al_get_text_dimensions"
 external get_font_ranges : font -> (int * int) array = "ml_al_get_font_ranges"
@@ -829,8 +830,8 @@ external init_ttf_addon : unit -> unit = "ml_al_init_ttf_addon"
 external is_ttf_addon_initialized : unit -> bool = "ml_al_is_ttf_addon_initialized"
 external shutdown_ttf_addon : unit -> unit = "ml_al_shutdown_ttf_addon"
 external get_allegro_ttf_version : unit -> int = "ml_al_get_allegro_ttf_version"
-external load_ttf_font : string -> ?flags: Ttf.flags -> int -> font = "ml_al_load_ttf_font"
-external load_ttf_font_stretch : string -> ?flags: Ttf.flags -> int -> int -> font = "ml_al_load_ttf_font_stretch"
+external load_ttf_font : string -> int -> Ttf.flags -> font = "ml_al_load_ttf_font"
+external load_ttf_font_stretch : string -> int -> int -> Ttf.flags -> font = "ml_al_load_ttf_font_stretch"
 
 
 (** {1 Primitives addon} *)

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -25,18 +25,6 @@ type sample_id
 
 type pos = float * float
 
-module type FLAG = sig
-  type flags = private int
-
-  val none : flags
-  val lnot : flags -> int
-  val ( lor ) : flags -> flags -> flags
-  val ( land ) : flags -> int -> flags
-  (** You may use type coercion i.e. [(my_flags :> int)]. *)
-
-  val ( lxor ) : flags -> flags -> flags
-end
-
 module DisplayMode : sig
   type t = {
     width : int;
@@ -86,6 +74,19 @@ module TouchState : sig
 end
 
 (** {2 Enumerations and flags} *)
+
+module type FLAG = sig
+  type flags = private int
+
+  val none : flags
+
+  val lnot : flags -> int
+  val ( lor ) : flags -> flags -> flags
+  val ( land ) : flags -> int -> flags
+  (** You may use type coercion i.e. [(my_flags :> int)]. *)
+
+  val ( lxor ) : flags -> flags -> flags
+end
 
 module Display : sig
   include FLAG
@@ -576,7 +577,7 @@ external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> 
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
 external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos ->pos -> pos -> pos -> float -> Flip.flags -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
 external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -25,6 +25,15 @@ type sample_id
 
 type pos = float * float
 
+module type FLAG = sig
+  type flags = private int
+
+  val lnot : flags -> int
+  val ( lor ) : flags -> flags -> flags
+  val ( land ) : flags -> int -> flags
+  val ( lxor ) : flags -> int -> int
+end
+
 module DisplayMode : sig
   type t = {
     width : int;
@@ -76,28 +85,33 @@ end
 (** {2 Enumerations and flags} *)
 
 module Display : sig
-  val windowed : int
-  val fullscreen_window : int
-  val fullscreen : int
-  val resizable : int
-  val maximized : int
-  val opengl : int
-  val opengl_3_0 : int
-  val opengl_forward_compatible : int
-  val opengl_es_profile : int
-  val opengl_core_profile : int
-  val direct3d : int
-  val programmable_pipeline : int
-  val frameless : int
-  val generate_expose_events : int
-  val gtk_toplevel : int
-  val drag_and_drop : int
+  include FLAG
+
+  val windowed : flags
+  val fullscreen : flags
+  val opengl : flags
+  val direct3d_internal : flags
+  val resizable : flags
+  val frameless : flags
+  val generate_expose_events : flags
+  val opengl_3_0 : flags
+  val opengl_forward_compatible : flags
+  val fullscreen_window : flags
+  val minimized : flags
+  val programmable_pipeline : flags
+  val gtk_toplevel : flags
+  val maximized : flags
+  val opengl_es_profile : flags
+  val opengl_core_profile : flags
+  val drag_and_drop : flags
 end
 
 module Bitmap : sig
-  val no_premultiplied_alpha : int
-  val keep_index : int
-  val keep_bitmap_format : int
+  include FLAG
+
+  val keep_bitmap_format : flags
+  val no_premultiplied_alpha : flags
+  val keep_index : flags
 end
 
 module Key : sig
@@ -236,28 +250,32 @@ module Key : sig
 end
 
 module Keymod : sig
-  val shift : int
-  val ctrl : int
-  val alt : int
-  val lwin : int
-  val rwin : int
-  val menu : int
-  val altgr : int
-  val command : int
-  val scrolllock : int
-  val numlock : int
-  val capslock : int
-  val inaltseq : int
-  val accent1 : int
-  val accent2 : int
-  val accent3 : int
-  val accent4 : int
+  include FLAG
+
+  val shift : flags
+  val ctrl : flags
+  val alt : flags
+  val lwin : flags
+  val rwin : flags
+  val menu : flags
+  val altgr : flags
+  val command : flags
+  val scrolllock : flags
+  val numlock : flags
+  val capslock : flags
+  val inaltseq : flags
+  val accent1 : flags
+  val accent2 : flags
+  val accent3 : flags
+  val accent4 : flags
 end
 
 module MouseButton : sig
-  val left : int
-  val right : int
-  val middle : int
+  type t = private int
+
+  val left : t
+  val right : t
+  val middle : t
 end
 
 module DisplayOrientation : sig
@@ -271,9 +289,11 @@ module DisplayOrientation : sig
   | FACE_DOWN
 end
 
-module Flip : sig
-  val horizontal : int
-  val vertical : int
+module Draw : sig
+  include FLAG
+
+  val flip_horizontal : flags
+  val flip_vertical : flags
 end
 
 module ShaderType : sig
@@ -322,16 +342,29 @@ module LineCap : sig
 end
 
 module Text : sig
-  val align_left : int
-  val align_centre : int
-  val align_right : int
-  val align_integer : int
+  type flags = private int
+  type align_integer_flag = private int
+
+  val ( lor ) : flags -> align_integer_flag -> flags
+
+  val align_left : flags
+  val align_centre : flags
+  val align_right : flags
+  val align_integer : align_integer_flag
 end
 
 module Ttf : sig
-  val no_kerning : int
-  val monochrome : int
-  val no_autohint : int
+  include FLAG
+
+  val no_kerning : flags
+  val monochrome : flags
+  val no_autohint : flags
+end
+
+module BitmapFont : sig
+  include FLAG
+
+  val no_premultiplied_alpha : flags
 end
 
 module Playmode : sig
@@ -340,6 +373,15 @@ module Playmode : sig
   | LOOP
   | LOOP_ONCE
   | BIDIR
+end
+
+module KeyboardLeds : sig
+  include FLAG
+
+  val numlock : flags
+  val capslock : flags
+  val scrolllock : flags
+  val default : flags
 end
 
 (** {2 Events} *)
@@ -363,7 +405,7 @@ module Event : sig
       y : int;
       z : int;
       w : int;
-      button : int;
+      button : MouseButton.t;
       pressure : float;
       display : display;
     }
@@ -391,7 +433,7 @@ module Event : sig
   | JOYSTICK_CONFIGURATION
   | KEY_DOWN of Key.t * display
   | KEY_UP of Key.t * display
-  | KEY_CHAR of Key.t * int * int * bool * display
+  | KEY_CHAR of Key.t * int * Keymod.flags * bool * display
   | MOUSE_AXES of MouseMove.t
   | MOUSE_BUTTON_DOWN of MouseButton.t
   | MOUSE_BUTTON_UP of MouseButton.t
@@ -428,8 +470,8 @@ end
 
 external create_display : int -> int -> display = "ml_al_create_display"
 external destroy_display : display -> unit = "ml_al_destroy_display"
-external get_new_display_flags : unit -> int = "ml_al_get_new_display_flags"
-external set_new_display_flags : int -> unit = "ml_al_set_new_display_flags"
+external get_new_display_flags : unit -> Display.flags = "ml_al_get_new_display_flags"
+external set_new_display_flags : Display.flags -> unit = "ml_al_set_new_display_flags"
 
 (** {2 Display operations} *)
 
@@ -526,16 +568,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> pos -> int -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> int -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> ?flags: Draw.flags ->pos -> pos -> pos -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> int -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> float -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> int -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> pos -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> float -> int -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> ?flags: Draw.flags -> pos ->pos -> pos -> pos -> float -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> int -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> ?flags: Draw.flags -> pos -> pos -> pos -> float -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"
@@ -555,7 +597,7 @@ external is_bitmap_drawing_held : unit -> bool = "ml_al_is_bitmap_drawing_held"
 
 (** {2 Image I/O} *)
 
-external register_bitmap_loader : string -> (string -> int -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
+external register_bitmap_loader : string -> (string -> Bitmap.flags -> bitmap option) option -> unit = "ml_al_register_bitmap_loader"
 external register_bitmap_saver : string -> (string -> bitmap -> bool) option -> unit = "ml_al_register_bitmap_saver"
 external load_bitmap : string -> bitmap = "ml_al_load_bitmap"
 external load_bitmap_flags : string -> int -> bitmap = "ml_al_load_bitmap_flags"
@@ -603,8 +645,7 @@ external get_keyboard_state : unit -> KeyboardState.t = "ml_al_get_keyboard_stat
 external key_down : KeyboardState.t -> Key.t -> bool = "ml_al_key_down"
 external keycode_to_name : Key.t -> string = "ml_al_keycode_to_name"
 external can_set_keyboard_leds : unit -> bool = "ml_al_can_set_keyboard_leds"
-external set_keyboard_leds : int -> unit = "ml_al_set_keyboard_leds"
-
+external set_keyboard_leds : KeyboardLeds.flags -> unit = "ml_al_set_keyboard_leds"
 
 (** {1 Mouse routines} *)
 
@@ -619,7 +660,7 @@ external get_mouse_num_axis : unit -> int = "ml_al_get_mouse_num_axes"
 external get_mouse_num_buttons : unit -> int = "ml_al_get_mouse_num_buttons"
 external get_mouse_state : unit -> MouseState.t = "ml_al_get_mouse_state"
 external get_mouse_state_axis : MouseState.t -> int -> int = "ml_al_get_mouse_state_axis"
-external mouse_button_down : MouseState.t -> int -> bool = "ml_al_mouse_button_down"
+external mouse_button_down : MouseState.t -> MouseButton.t -> bool = "ml_al_mouse_button_down"
 external set_mouse_xy : display -> int -> int -> bool = "ml_al_set_mouse_xy"
 external set_mouse_z : int -> bool = "ml_al_set_mouse_z"
 external set_mouse_w : int -> bool = "ml_al_set_mouse_w"
@@ -765,8 +806,8 @@ external get_font_line_height : font -> int = "ml_al_get_font_line_height"
 external get_font_ascent : font -> int = "ml_al_get_font_ascent"
 external get_font_descent : font -> int = "ml_al_get_font_descent"
 external get_text_width : font -> string -> int = "ml_al_get_text_width"
-external draw_text : font -> color -> pos -> int -> string -> unit = "ml_al_draw_text"
-external draw_justified_text : font -> color -> pos -> float -> float -> int -> string -> unit =
+external draw_text : font -> ?flags: Text.flags -> color -> pos -> string -> unit = "ml_al_draw_text"
+external draw_justified_text : font -> ?flags: Text.align_integer_flag -> color -> pos -> float -> float -> string -> unit =
   "ml_al_draw_justified_text_bytecode" "ml_al_draw_justified_text"
 external get_text_dimensions : font -> string -> int * int * int * int = "ml_al_get_text_dimensions"
 external get_font_ranges : font -> (int * int) array = "ml_al_get_font_ranges"
@@ -777,7 +818,7 @@ external get_fallback_font : font -> font = "ml_al_get_fallback_font"
 
 external grab_font_from_bitmap : bitmap -> (int * int) array -> font = "ml_al_grab_font_from_bitmap"
 external load_bitmap_font : string -> font = "ml_al_load_bitmap_font"
-external load_bitmap_font_flags : string -> int -> font = "ml_al_load_bitmap_font_flags"
+external load_bitmap_font_flags : string -> BitmapFont.flags -> font = "ml_al_load_bitmap_font_flags"
 external create_builtin_font : unit -> font = "ml_al_create_builtin_font"
 
 (** {2 TTF fonts} *)
@@ -786,8 +827,8 @@ external init_ttf_addon : unit -> unit = "ml_al_init_ttf_addon"
 external is_ttf_addon_initialized : unit -> bool = "ml_al_is_ttf_addon_initialized"
 external shutdown_ttf_addon : unit -> unit = "ml_al_shutdown_ttf_addon"
 external get_allegro_ttf_version : unit -> int = "ml_al_get_allegro_ttf_version"
-external load_ttf_font : string -> int -> int -> font = "ml_al_load_ttf_font"
-external load_ttf_font_stretch : string -> int -> int -> int -> font = "ml_al_load_ttf_font_stretch"
+external load_ttf_font : string -> ?flags: Ttf.flags -> int -> font = "ml_al_load_ttf_font"
+external load_ttf_font_stretch : string -> ?flags: Ttf.flags -> int -> int -> font = "ml_al_load_ttf_font_stretch"
 
 
 (** {1 Primitives addon} *)

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -31,6 +31,8 @@ module type FLAG = sig
   val lnot : flags -> int
   val ( lor ) : flags -> flags -> flags
   val ( land ) : flags -> int -> flags
+  (** You may use type coercion i.e. [(my_flags :> int)]. *)
+
   val ( lxor ) : flags -> int -> int
 end
 

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -290,11 +290,11 @@ module DisplayOrientation : sig
   | FACE_DOWN
 end
 
-module Draw : sig
+module Flip : sig
   include FLAG
 
-  val flip_horizontal : flags
-  val flip_vertical : flags
+  val horizontal : flags
+  val vertical : flags
 end
 
 module ShaderType : sig
@@ -569,16 +569,16 @@ external reparent_bitmap : bitmap -> bitmap -> int -> int -> int -> int =
 (** {2 Drawing operations} *)
 
 external clear_to_color : color -> unit = "ml_al_clear_to_color"
-external draw_bitmap : bitmap -> ?tint: color -> pos -> Draw.flags -> unit = "ml_al_draw_bitmap"
-external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Draw.flags -> unit =
+external draw_bitmap : bitmap -> ?tint: color -> pos -> Flip.flags -> unit = "ml_al_draw_bitmap"
+external draw_bitmap_region : bitmap -> ?tint: color -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_bitmap_region_bytecode" "ml_al_draw_bitmap_region"
-external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_rotated_bitmap : bitmap -> ?tint: color -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_rotated_bitmap_bytecode" "ml_al_draw_rotated_bitmap"
-external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Draw.flags -> unit =
+external draw_scaled_bitmap : bitmap -> ?tint: color -> pos -> pos -> pos -> pos -> Flip.flags -> unit =
   "ml_al_draw_scaled_bitmap_bytecode" "ml_al_draw_scaled_bitmap"
-external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos ->pos -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_scaled_rotated_bitmap : bitmap -> ?tint: color -> pos ->pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_bytecode" "ml_al_draw_scaled_rotated_bitmap"
-external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Draw.flags -> unit =
+external draw_scaled_rotated_bitmap_region : bitmap -> pos -> pos -> ?tint: color -> pos -> pos -> pos -> float -> Flip.flags -> unit =
   "ml_al_draw_scaled_rotated_bitmap_region_bytecode" "ml_al_draw_scaled_rotated_bitmap_region"
 external put_pixel : int -> int -> color -> unit = "ml_al_put_pixel"
 external put_blended_pixel : int -> int -> color -> unit = "ml_al_put_blended_pixel"

--- a/lib/al5.mli
+++ b/lib/al5.mli
@@ -274,11 +274,9 @@ module Keymod : sig
 end
 
 module MouseButton : sig
-  type t = private int
-
-  val left : t
-  val right : t
-  val middle : t
+  val left : int
+  val right : int
+  val middle : int
 end
 
 module DisplayOrientation : sig
@@ -408,7 +406,7 @@ module Event : sig
       y : int;
       z : int;
       w : int;
-      button : MouseButton.t;
+      button : int;
       pressure : float;
       display : display;
     }
@@ -663,7 +661,7 @@ external get_mouse_num_axis : unit -> int = "ml_al_get_mouse_num_axes"
 external get_mouse_num_buttons : unit -> int = "ml_al_get_mouse_num_buttons"
 external get_mouse_state : unit -> MouseState.t = "ml_al_get_mouse_state"
 external get_mouse_state_axis : MouseState.t -> int -> int = "ml_al_get_mouse_state_axis"
-external mouse_button_down : MouseState.t -> MouseButton.t -> bool = "ml_al_mouse_button_down"
+external mouse_button_down : MouseState.t -> int -> bool = "ml_al_mouse_button_down"
 external set_mouse_xy : display -> int -> int -> bool = "ml_al_set_mouse_xy"
 external set_mouse_z : int -> bool = "ml_al_set_mouse_z"
 external set_mouse_w : int -> bool = "ml_al_set_mouse_w"

--- a/lib/display.c
+++ b/lib/display.c
@@ -2,22 +2,25 @@
 
 
 enum {
-    ML_WINDOWED = 1 << 0,
-    ML_FULLSCREEN_WINDOW = 1 << 1,
-    ML_FULLSCREEN = 1 << 2,
-    ML_RESIZABLE = 1 << 3,
-    ML_MAXIMIZED = 1 << 4,
-    ML_OPENGL = 1 << 5,
-    ML_OPENGL_3_0 = 1 << 6,
-    ML_OPENGL_FORWARD_COMPATIBLE = 1 << 7,
-    ML_OPENGL_ES_PROFILE = 1 << 8,
-    ML_OPENGL_CORE_PROFILE = 1 << 9,
-    ML_DIRECT3D = 1 << 10,
-    ML_PROGRAMMABLE_PIPELINE = 1 << 11,
-    ML_FRAMELESS = 1 << 12,
-    ML_GENERATE_EXPOSE_EVENTS = 1 << 13,
-    ML_GTK_TOPLEVEL = 1 << 14,
-    ML_DRAG_AND_DROP = 1 << 15,
+   ML_WINDOWED                    = 1 << 0,
+   ML_FULLSCREEN                  = 1 << 1,
+   ML_OPENGL                      = 1 << 2,
+   ML_DIRECT3D_INTERNAL           = 1 << 3,
+   ML_RESIZABLE                   = 1 << 4,
+   ML_FRAMELESS                   = 1 << 5,
+   ML_GENERATE_EXPOSE_EVENTS      = 1 << 6,
+   ML_OPENGL_3_0                  = 1 << 7,
+   ML_OPENGL_FORWARD_COMPATIBLE   = 1 << 8,
+   ML_FULLSCREEN_WINDOW           = 1 << 9,
+   ML_MINIMIZED                   = 1 << 10,
+   ML_PROGRAMMABLE_PIPELINE       = 1 << 11,
+   ML_GTK_TOPLEVEL_INTERNAL       = 1 << 12,
+   ML_MAXIMIZED                   = 1 << 13,
+   ML_OPENGL_ES_PROFILE           = 1 << 14,
+#if defined(ML_UNSTABLE)
+   ML_OPENGL_CORE_PROFILE         = 1 << 15,
+   ML_DRAG_AND_DROP               = 1 << 16,
+#endif
 };
 
 static int const display_flags_conv[][2] = {

--- a/lib/display.c
+++ b/lib/display.c
@@ -2,24 +2,24 @@
 
 
 enum {
-   ML_WINDOWED                    = 1 << 0,
-   ML_FULLSCREEN                  = 1 << 1,
-   ML_OPENGL                      = 1 << 2,
-   ML_DIRECT3D_INTERNAL           = 1 << 3,
-   ML_RESIZABLE                   = 1 << 4,
-   ML_FRAMELESS                   = 1 << 5,
-   ML_GENERATE_EXPOSE_EVENTS      = 1 << 6,
-   ML_OPENGL_3_0                  = 1 << 7,
-   ML_OPENGL_FORWARD_COMPATIBLE   = 1 << 8,
-   ML_FULLSCREEN_WINDOW           = 1 << 9,
-   ML_MINIMIZED                   = 1 << 10,
-   ML_PROGRAMMABLE_PIPELINE       = 1 << 11,
-   ML_GTK_TOPLEVEL_INTERNAL       = 1 << 12,
-   ML_MAXIMIZED                   = 1 << 13,
-   ML_OPENGL_ES_PROFILE           = 1 << 14,
-#if defined(ML_UNSTABLE)
-   ML_OPENGL_CORE_PROFILE         = 1 << 15,
-   ML_DRAG_AND_DROP               = 1 << 16,
+    ML_WINDOWED                    = 1 << 0,
+    ML_FULLSCREEN                  = 1 << 1,
+    ML_OPENGL                      = 1 << 2,
+    ML_DIRECT3D_INTERNAL           = 1 << 3,
+    ML_RESIZABLE                   = 1 << 4,
+    ML_FRAMELESS                   = 1 << 5,
+    ML_GENERATE_EXPOSE_EVENTS      = 1 << 6,
+    ML_OPENGL_3_0                  = 1 << 7,
+    ML_OPENGL_FORWARD_COMPATIBLE   = 1 << 8,
+    ML_FULLSCREEN_WINDOW           = 1 << 9,
+    ML_MINIMIZED                   = 1 << 10,
+    ML_PROGRAMMABLE_PIPELINE       = 1 << 11,
+    ML_GTK_TOPLEVEL_INTERNAL       = 1 << 12,
+    ML_MAXIMIZED                   = 1 << 13,
+    ML_OPENGL_ES_PROFILE           = 1 << 14,
+#if defined ML_UNSTABLE
+    ML_OPENGL_CORE_PROFILE         = 1 << 15,
+    ML_DRAG_AND_DROP               = 1 << 16,
 #endif
 };
 

--- a/lib/font.c
+++ b/lib/font.c
@@ -49,20 +49,20 @@ CAMLprim value ml_al_get_text_width(value font, value str)
     CAMLreturn(Val_int(width));
 }
 
-CAMLprim value ml_al_draw_text(value font, value flags, value color, value pos, value text)
+CAMLprim value ml_al_draw_text(value font, value color, value pos, value flags, value text)
 {
-    CAMLparam5(font, flags, color, pos, text);
-    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), text_flags_conv, 0) : 0;
+    CAMLparam5(font, color, pos, flags, text);
+    int c_flags = convert_flags(Int_val(flags), text_flags_conv, 0);
     al_draw_text(Ptr_val(font), AlColor_val(color),
         PosX_val(pos), PosY_val(pos), c_flags, String_val(text));
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value ml_al_draw_justified_text(value font, value flags, value color, value pos, value x2, value diff, value text)
+CAMLprim value ml_al_draw_justified_text(value font, value color, value pos, value x2, value diff, value flags, value text)
 {
-    CAMLparam5(font, flags, color, pos, x2);
-    CAMLxparam2(diff, text);
-    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), text_flags_conv, 0) : 0;
+    CAMLparam5(font, color, pos, x2, diff);
+    CAMLxparam2(flags, text);
+    int c_flags = convert_flags(Int_val(flags), text_flags_conv, 0);
     al_draw_justified_text(Ptr_val(font), AlColor_val(color),
         PosX_val(pos), Double_val(x2), PosY_val(pos), Double_val(diff),
         c_flags, String_val(text));
@@ -173,18 +173,18 @@ ml_function_noarg(al_shutdown_ttf_addon)
 
 ml_function_noarg_ret(al_get_allegro_ttf_version, Val_int)
 
-CAMLprim value ml_al_load_ttf_font(value filename, value flags, value size)
+CAMLprim value ml_al_load_ttf_font(value filename, value size, value flags)
 {
-    CAMLparam3(filename, flags, size);
-    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), ttf_flags_conv, 0) : 0;
+    CAMLparam3(filename, size, flags);
+    int c_flags = convert_flags(Int_val(flags), ttf_flags_conv, 0);
     ALLEGRO_FONT *font = al_load_ttf_font(String_val(filename), Int_val(size), c_flags);
     CAMLreturn(Val_ptr(font));
 }
 
-CAMLprim value ml_al_load_ttf_font_stretch(value filename, value flags, value w, value h)
+CAMLprim value ml_al_load_ttf_font_stretch(value filename, value w, value h, value flags)
 {
-    CAMLparam4(filename, flags, w, h);
-    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), ttf_flags_conv, 0) : 0;
+    CAMLparam4(filename, w, h, flags);
+    int c_flags = convert_flags(Int_val(flags), ttf_flags_conv, 0);
     ALLEGRO_FONT *font = al_load_ttf_font_stretch(
         String_val(filename), Int_val(w), Int_val(h), c_flags);
     CAMLreturn(Val_ptr(font));

--- a/lib/font.c
+++ b/lib/font.c
@@ -21,10 +21,10 @@ ml_function_noarg_ret(al_get_allegro_font_version, Val_int)
 
 
 enum {
-    ML_ALIGN_LEFT = 1 << 0,
-    ML_ALIGN_CENTRE = 1 << 1,
-    ML_ALIGN_RIGHT = 1 << 2,
-    ML_ALIGN_INTEGER = 1 << 3,
+    ML_ALIGN_LEFT = 0,
+    ML_ALIGN_CENTRE = 1 << 0,
+    ML_ALIGN_RIGHT = 1 << 1,
+    ML_ALIGN_INTEGER = 1 << 2,
 };
 
 static int const text_flags_conv[][2] = {
@@ -49,20 +49,20 @@ CAMLprim value ml_al_get_text_width(value font, value str)
     CAMLreturn(Val_int(width));
 }
 
-CAMLprim value ml_al_draw_text(value font, value color, value pos, value flags, value text)
+CAMLprim value ml_al_draw_text(value font, value flags, value color, value pos, value text)
 {
-    CAMLparam5(font, color, pos, flags, text);
-    int c_flags = convert_flags(Int_val(flags), text_flags_conv, 0);
+    CAMLparam5(font, flags, color, pos, text);
+    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), text_flags_conv, 0) : 0;
     al_draw_text(Ptr_val(font), AlColor_val(color),
         PosX_val(pos), PosY_val(pos), c_flags, String_val(text));
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value ml_al_draw_justified_text(value font, value color, value pos, value x2, value diff, value flags, value text)
+CAMLprim value ml_al_draw_justified_text(value font, value flags, value color, value pos, value x2, value diff, value text)
 {
-    CAMLparam5(font, color, pos, x2, diff);
-    CAMLxparam2(flags, text);
-    int c_flags = convert_flags(Int_val(flags), text_flags_conv, 0);
+    CAMLparam5(font, flags, color, pos, x2);
+    CAMLxparam2(diff, text);
+    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), text_flags_conv, 0) : 0;
     al_draw_justified_text(Ptr_val(font), AlColor_val(color),
         PosX_val(pos), Double_val(x2), PosY_val(pos), Double_val(diff),
         c_flags, String_val(text));
@@ -173,18 +173,18 @@ ml_function_noarg(al_shutdown_ttf_addon)
 
 ml_function_noarg_ret(al_get_allegro_ttf_version, Val_int)
 
-CAMLprim value ml_al_load_ttf_font(value filename, value size, value flags)
+CAMLprim value ml_al_load_ttf_font(value filename, value flags, value size)
 {
-    CAMLparam3(filename, size, flags);
-    int c_flags = convert_flags(Int_val(flags), ttf_flags_conv, 0);
+    CAMLparam3(filename, flags, size);
+    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), ttf_flags_conv, 0) : 0;
     ALLEGRO_FONT *font = al_load_ttf_font(String_val(filename), Int_val(size), c_flags);
     CAMLreturn(Val_ptr(font));
 }
 
-CAMLprim value ml_al_load_ttf_font_stretch(value filename, value w, value h, value flags)
+CAMLprim value ml_al_load_ttf_font_stretch(value filename, value flags, value w, value h)
 {
-    CAMLparam4(filename, w, h, flags);
-    int c_flags = convert_flags(Int_val(flags), ttf_flags_conv, 0);
+    CAMLparam4(filename, flags, w, h);
+    int c_flags = Is_some(flags) ? convert_flags(Int_val(Some_val(flags)), ttf_flags_conv, 0) : 0;
     ALLEGRO_FONT *font = al_load_ttf_font_stretch(
         String_val(filename), Int_val(w), Int_val(h), c_flags);
     CAMLreturn(Val_ptr(font));

--- a/lib/graphics.c
+++ b/lib/graphics.c
@@ -201,33 +201,35 @@ static int convert_draw_bitmap_flags_from_ml(value flags)
 
 ml_function_1arg(al_clear_to_color, AlColor_val)
 
-CAMLprim value ml_al_draw_bitmap(value bmp, value tint, value dpos, value flags)
+CAMLprim value ml_al_draw_bitmap(value bmp, value tint, value flags, value dpos)
 {
-    CAMLparam4(bmp, tint, dpos, flags);
+    CAMLparam4(bmp, tint, flags, dpos);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+
     if (Is_none(tint)) {
-        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos),
-            convert_draw_bitmap_flags_from_ml(flags));
+        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos), c_flags);
     } else {
-        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
-            PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
+        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)), PosX_val(dpos), PosY_val(dpos), c_flags);
     }
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value ml_al_draw_bitmap_region(value bmp, value tint, value spos, value ssize, value dpos, value flags)
+CAMLprim value ml_al_draw_bitmap_region(value bmp, value tint, value flags, value spos, value ssize, value dpos)
 {
-    CAMLparam5(bmp, tint, spos, ssize, dpos);
-    CAMLxparam1(flags);
+    CAMLparam5(bmp, tint, flags, spos, ssize);
+    CAMLxparam1(dpos);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+
     if (Is_none(tint)) {
         al_draw_bitmap_region(Ptr_val(bmp),
             PosX_val(spos), PosY_val(spos),
             PosX_val(ssize), PosY_val(ssize),
-            PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
+            PosX_val(dpos), PosY_val(dpos), c_flags);
     } else {
         al_draw_tinted_bitmap_region(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(spos), PosY_val(spos),
             PosX_val(ssize), PosY_val(ssize),
-            PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
+            PosX_val(dpos), PosY_val(dpos), c_flags);
     }
     CAMLreturn(Val_unit);
 }
@@ -238,18 +240,19 @@ CAMLprim value ml_al_draw_bitmap_region_bytecode(value *argv, int argc)
         argv[2], argv[3], argv[4], argv[5]);
 }
 
-CAMLprim value ml_al_draw_rotated_bitmap(value bmp, value tint, value cpos, value dpos, value angle, value flags)
+CAMLprim value ml_al_draw_rotated_bitmap(value bmp, value tint, value flags, value cpos, value dpos, value angle)
 {
-    CAMLparam5(bmp, tint, cpos, dpos, angle);
-    CAMLxparam1(flags);
+    CAMLparam5(bmp, tint, flags, cpos, dpos);
+    CAMLxparam1(angle);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
     if (Is_none(tint)) {
         al_draw_rotated_bitmap(Ptr_val(bmp),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
-            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
+            Double_val(angle), c_flags);
     } else {
         al_draw_tinted_rotated_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
-            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
+            Double_val(angle), c_flags);
     }
     CAMLreturn(Val_unit);
 }
@@ -261,20 +264,21 @@ CAMLprim value ml_al_draw_rotated_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_bitmap(
-    value bmp, value tint, value spos, value ssize, value dpos, value dsize, value flags)
+    value bmp, value tint, value flags, value spos, value ssize, value dpos, value dsize)
 {
-    CAMLparam5(bmp, tint, spos, ssize, dpos);
-    CAMLxparam2(dsize, flags);
+    CAMLparam5(bmp, tint, flags, spos, ssize);
+    CAMLxparam2(dpos, dsize);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
     if (Is_none(tint)) {
         al_draw_scaled_bitmap(Ptr_val(bmp),
             PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
             PosX_val(dpos), PosY_val(dpos), PosX_val(dsize), PosY_val(dsize),
-            convert_draw_bitmap_flags_from_ml(flags));
+            c_flags);
     } else {
         al_draw_tinted_scaled_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
             PosX_val(dpos), PosY_val(dpos), PosX_val(dsize), PosY_val(dsize),
-            convert_draw_bitmap_flags_from_ml(flags));
+            c_flags);
     }
     CAMLreturn(Val_unit);
 }
@@ -286,20 +290,22 @@ CAMLprim value ml_al_draw_scaled_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_rotated_bitmap(
-    value bmp, value tint, value cpos, value dpos, value scale, value angle, value flags)
+    value bmp, value tint, value flags, value cpos, value dpos, value scale, value angle)
 {
-    CAMLparam5(bmp, tint, cpos, dpos, scale);
-    CAMLxparam2(angle, flags);
+    CAMLparam5(bmp, tint, flags, cpos, dpos);
+    CAMLxparam2(scale, angle);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+
     if (Is_none(tint)) {
         al_draw_scaled_rotated_bitmap(Ptr_val(bmp),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
             PosX_val(scale), PosY_val(scale),
-            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
+            Double_val(angle), c_flags);
     } else {
         al_draw_tinted_scaled_rotated_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
             PosX_val(scale), PosY_val(scale),
-            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
+            Double_val(angle), c_flags);
     }
     CAMLreturn(Val_unit);
 }
@@ -311,16 +317,17 @@ CAMLprim value ml_al_draw_scaled_rotated_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_rotated_bitmap_region(
-    value bmp, value spos, value ssize, value tint, value cpos, value dpos, value scale, value angle, value flags)
+    value bmp, value spos, value ssize, value tint, value flags, value cpos, value dpos, value scale, value angle)
 {
-    CAMLparam5(bmp, spos, ssize, tint, cpos);
-    CAMLxparam4(dpos, scale, angle, flags);
+    CAMLparam5(bmp, spos, ssize, tint, flags);
+    CAMLxparam4(cpos, dpos, scale, angle);
+    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
     al_draw_tinted_scaled_rotated_bitmap_region(Ptr_val(bmp),
         PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
         Is_none(tint) ? al_map_rgb(255, 255, 255) : AlColor_val(Some_val(tint)),
         PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
         PosX_val(scale), PosY_val(scale),
-        Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
+        Double_val(angle), c_flags);
     CAMLreturn(Val_unit);
 }
 
@@ -367,9 +374,9 @@ ml_function_noarg_ret(al_is_bitmap_drawing_held, Val_bool)
 
 
 enum {
-    ML_NO_PREMULTIPLIED_ALPHA = 1 << 0,
-    ML_KEEP_INDEX = 1 << 1,
-    ML_KEEP_BITMAP_FORMAT = 1 << 2,
+    ML_KEEP_BITMAP_FORMAT = 1 << 1,
+    ML_NO_PREMULTIPLIED_ALPHA = 1 << 9,
+    ML_KEEP_INDEX = 1 << 11,
 };
 
 static int const load_flags_conv[][2] = {

--- a/lib/graphics.c
+++ b/lib/graphics.c
@@ -201,35 +201,33 @@ static int convert_draw_bitmap_flags_from_ml(value flags)
 
 ml_function_1arg(al_clear_to_color, AlColor_val)
 
-CAMLprim value ml_al_draw_bitmap(value bmp, value tint, value flags, value dpos)
+CAMLprim value ml_al_draw_bitmap(value bmp, value tint, value dpos, value flags)
 {
-    CAMLparam4(bmp, tint, flags, dpos);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam4(bmp, tint, dpos, flags);
 
     if (Is_none(tint)) {
-        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos), c_flags);
+        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
     } else {
-        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)), PosX_val(dpos), PosY_val(dpos), c_flags);
+        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)), PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value ml_al_draw_bitmap_region(value bmp, value tint, value flags, value spos, value ssize, value dpos)
+CAMLprim value ml_al_draw_bitmap_region(value bmp, value tint, value spos, value ssize, value dpos, value flags)
 {
-    CAMLparam5(bmp, tint, flags, spos, ssize);
-    CAMLxparam1(dpos);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam5(bmp, tint, spos, ssize, dpos);
+    CAMLxparam1(flags);
 
     if (Is_none(tint)) {
         al_draw_bitmap_region(Ptr_val(bmp),
             PosX_val(spos), PosY_val(spos),
             PosX_val(ssize), PosY_val(ssize),
-            PosX_val(dpos), PosY_val(dpos), c_flags);
+            PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
     } else {
         al_draw_tinted_bitmap_region(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(spos), PosY_val(spos),
             PosX_val(ssize), PosY_val(ssize),
-            PosX_val(dpos), PosY_val(dpos), c_flags);
+            PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
@@ -240,19 +238,18 @@ CAMLprim value ml_al_draw_bitmap_region_bytecode(value *argv, int argc)
         argv[2], argv[3], argv[4], argv[5]);
 }
 
-CAMLprim value ml_al_draw_rotated_bitmap(value bmp, value tint, value flags, value cpos, value dpos, value angle)
+CAMLprim value ml_al_draw_rotated_bitmap(value bmp, value tint, value cpos, value dpos, value angle, value flags)
 {
-    CAMLparam5(bmp, tint, flags, cpos, dpos);
-    CAMLxparam1(angle);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam5(bmp, tint, cpos, dpos, angle);
+    CAMLxparam1(flags);
     if (Is_none(tint)) {
         al_draw_rotated_bitmap(Ptr_val(bmp),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
-            Double_val(angle), c_flags);
+            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
     } else {
         al_draw_tinted_rotated_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
-            Double_val(angle), c_flags);
+            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
@@ -264,21 +261,20 @@ CAMLprim value ml_al_draw_rotated_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_bitmap(
-    value bmp, value tint, value flags, value spos, value ssize, value dpos, value dsize)
+    value bmp, value tint, value spos, value ssize, value dpos, value dsize, value flags)
 {
-    CAMLparam5(bmp, tint, flags, spos, ssize);
-    CAMLxparam2(dpos, dsize);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam5(bmp, tint, spos, ssize, dpos);
+    CAMLxparam2(dsize, flags);
     if (Is_none(tint)) {
         al_draw_scaled_bitmap(Ptr_val(bmp),
             PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
             PosX_val(dpos), PosY_val(dpos), PosX_val(dsize), PosY_val(dsize),
-            c_flags);
+            convert_draw_bitmap_flags_from_ml(flags));
     } else {
         al_draw_tinted_scaled_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
             PosX_val(dpos), PosY_val(dpos), PosX_val(dsize), PosY_val(dsize),
-            c_flags);
+            convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
@@ -290,22 +286,21 @@ CAMLprim value ml_al_draw_scaled_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_rotated_bitmap(
-    value bmp, value tint, value flags, value cpos, value dpos, value scale, value angle)
+    value bmp, value tint, value cpos, value dpos, value scale, value angle, value flags)
 {
-    CAMLparam5(bmp, tint, flags, cpos, dpos);
-    CAMLxparam2(scale, angle);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam5(bmp, tint, cpos, dpos, scale);
+    CAMLxparam2(angle, flags);
 
     if (Is_none(tint)) {
         al_draw_scaled_rotated_bitmap(Ptr_val(bmp),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
             PosX_val(scale), PosY_val(scale),
-            Double_val(angle), c_flags);
+            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
     } else {
         al_draw_tinted_scaled_rotated_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
             PosX_val(scale), PosY_val(scale),
-            Double_val(angle), c_flags);
+            Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
@@ -317,17 +312,16 @@ CAMLprim value ml_al_draw_scaled_rotated_bitmap_bytecode(value *argv, int argc)
 }
 
 CAMLprim value ml_al_draw_scaled_rotated_bitmap_region(
-    value bmp, value spos, value ssize, value tint, value flags, value cpos, value dpos, value scale, value angle)
+    value bmp, value spos, value ssize, value tint, value cpos, value dpos, value scale, value angle, value flags)
 {
-    CAMLparam5(bmp, spos, ssize, tint, flags);
-    CAMLxparam4(cpos, dpos, scale, angle);
-    int c_flags = Is_none(flags) ? 0 : convert_draw_bitmap_flags_from_ml(Some_val(flags));
+    CAMLparam5(bmp, spos, ssize, tint, cpos);
+    CAMLxparam4(dpos, scale, angle, flags);
     al_draw_tinted_scaled_rotated_bitmap_region(Ptr_val(bmp),
         PosX_val(spos), PosY_val(spos), PosX_val(ssize), PosY_val(ssize),
         Is_none(tint) ? al_map_rgb(255, 255, 255) : AlColor_val(Some_val(tint)),
         PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),
         PosX_val(scale), PosY_val(scale),
-        Double_val(angle), c_flags);
+        Double_val(angle), convert_draw_bitmap_flags_from_ml(flags));
     CAMLreturn(Val_unit);
 }
 

--- a/lib/graphics.c
+++ b/lib/graphics.c
@@ -204,11 +204,12 @@ ml_function_1arg(al_clear_to_color, AlColor_val)
 CAMLprim value ml_al_draw_bitmap(value bmp, value tint, value dpos, value flags)
 {
     CAMLparam4(bmp, tint, dpos, flags);
-
     if (Is_none(tint)) {
-        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
+        al_draw_bitmap(Ptr_val(bmp), PosX_val(dpos), PosY_val(dpos),
+            convert_draw_bitmap_flags_from_ml(flags));
     } else {
-        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)), PosX_val(dpos), PosY_val(dpos), convert_draw_bitmap_flags_from_ml(flags));
+        al_draw_tinted_bitmap(Ptr_val(bmp), AlColor_val(Some_val(tint)), PosX_val(dpos), PosY_val(dpos),
+            convert_draw_bitmap_flags_from_ml(flags));
     }
     CAMLreturn(Val_unit);
 }
@@ -217,7 +218,6 @@ CAMLprim value ml_al_draw_bitmap_region(value bmp, value tint, value spos, value
 {
     CAMLparam5(bmp, tint, spos, ssize, dpos);
     CAMLxparam1(flags);
-
     if (Is_none(tint)) {
         al_draw_bitmap_region(Ptr_val(bmp),
             PosX_val(spos), PosY_val(spos),
@@ -290,7 +290,6 @@ CAMLprim value ml_al_draw_scaled_rotated_bitmap(
 {
     CAMLparam5(bmp, tint, cpos, dpos, scale);
     CAMLxparam2(angle, flags);
-
     if (Is_none(tint)) {
         al_draw_scaled_rotated_bitmap(Ptr_val(bmp),
             PosX_val(cpos), PosY_val(cpos), PosX_val(dpos), PosY_val(dpos),


### PR DESCRIPTION
This patch makes some changes to the API so that the bit flags are are safer to use. There are a couple of related changes in this.

* Add a new module type "FLAG" that defines a `type flags = private int` and implements bitwise operations that preserve that the values remain valid as flags are combined.
* Include the new "FLAG" module in modules that define bit flags.
* Change the bindings functions to use the __Module__.flags instead of int. In cases where the flags have a default of 0, this argument is made optional so they don't have to be passed.
* Change the event types to use the flags types instead of int where appropriate (eg key modifiers)
* Update the numeric values of flags to match the C code. This doesn't necessarily improve soundness, but does make it easier to figure out what's going on in the debugger. This makes the flag conversions somewhat redundant, but I left them in.

The Flags module implementation defines the logical operators with these signatures:

```ocaml
val lnot : flags -> int
val ( lor ) : flags -> flags -> flags
val ( land ) : flags -> int -> flags
val ( lxor ) : flags -> int -> int
```

I couldn't find a way to make the operators polymorphic, so `land` and `lxor` require a type coercion `(:> int)` if you use a flag as the right operand.

Here's an example of usage:

```ocaml

(* Good *)

let display_flags = Al5.Display.(windowed lor opengl lor frameless) in
Al5.set_new_display_flags display_flags

(* Caught at compile time *)

let display_flags = Al5.Display.windowed lor 0x0800
Error: The value Al5.Display.windowed has type Al5.Display.flags
       but an expression was expected of type int
```