### PR TITLE
Change dependencies of allego5_main library

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -30,8 +30,9 @@
  (name al5_main)
  (public_name allegro5_main)
  (modules al5_main)
+ (libraries allegro5)
  (foreign_stubs
   (language c)
   (names main)
   (flags :standard -std=c11 -Wall -O2 (:include c_flags.sexp)))
- (c_library_flags :standard (:include lib_flags.sexp)))
+ )


### PR DESCRIPTION
Link allegro5_main against allegro5 and don't repeat the linkage against the c libraries. This eliminates some warnings on linkage with some linkers.